### PR TITLE
Add capability to handling resources in module

### DIFF
--- a/tfstate-merge
+++ b/tfstate-merge
@@ -38,7 +38,7 @@ def load_file(name)
 end
 
 def address(resource)
-    [resource['mode'], resource['type'], resource['name']].join('.')
+    [resource['module'] || '', resource['mode'], resource['type'], resource['name']].join('.')
 end
 
 def merge_tfstates(dest, src)


### PR DESCRIPTION
without this fix, even if the modules are different resources will conflict.

```
 % tfstate-merge a.tfstate.json b.tfstate.json
Traceback (most recent call last):
        4: from /Users/kazufumi.nishida/bin/tfstate-merge:81:in `<main>'
        3: from /Users/kazufumi.nishida/bin/tfstate-merge:18:in `main'
        2: from /Users/kazufumi.nishida/bin/tfstate-merge:59:in `merge_tfstates'
        1: from /Users/kazufumi.nishida/bin/tfstate-merge:59:in `each'
/Users/kazufumi.nishida/bin/tfstate-merge:68:in `block in merge_tfstates': resources data.aws_region.current are different (RuntimeError)
```